### PR TITLE
Minor spelling tweaks and fixes.

### DIFF
--- a/Deform_Rig_Generator.py
+++ b/Deform_Rig_Generator.py
@@ -128,7 +128,7 @@ class GRT_Generate_Game_Rig(bpy.types.Operator):
         elif control_rig:
             self.Deform_Armature_Name = control_rig.name + "_deform"
 
-            
+
 
         return context.window_manager.invoke_props_dialog(self)
 
@@ -154,9 +154,9 @@ class GRT_Generate_Game_Rig(bpy.types.Operator):
             layout.label(text="Turn this off if you are unsure")
             layout.label(text="the safety of this script")
             layout.prop(Global_Settings, "post_generation_script", text="")
-            
-            
-            
+
+
+
 
         if Utility.draw_subpanel(
             self,
@@ -641,13 +641,13 @@ def draw_item(self, context):
 
     addon_preferences = context.preferences.addons[addon_name].preferences
 
-    if addon_preferences.toogle_constraints:
+    if addon_preferences.toggle_constraints:
         if context.mode == "POSE":
-            operator = row.operator("gamerigtool.toogle_constraint", text="Mute")
+            operator = row.operator("gamerigtool.toggle_constraint", text="Mute")
             operator.mute = True
             operator.use_selected = addon_preferences.use_selected
 
-            operator = row.operator("gamerigtool.toogle_constraint", text="Unmute")
+            operator = row.operator("gamerigtool.toggle_constraint", text="Unmute")
             operator.mute = False
             operator.use_selected = addon_preferences.use_selected
 

--- a/Deform_Rig_Panel.py
+++ b/Deform_Rig_Panel.py
@@ -144,11 +144,11 @@ def draw_panel(self, context, layout):
 
     # row = layout.row(align=True)
 
-    # operator = row.operator("gamerigtool.toogle_constraint", text="Mute", icon="HIDE_ON")
+    # operator = row.operator("gamerigtool.toggle_constraint", text="Mute", icon="HIDE_ON")
     # operator.mute = True
     # operator.use_selected = addon_preferences.use_selected
 
-    # operator = row.operator("gamerigtool.toogle_constraint", text="Unmute", icon="HIDE_OFF")
+    # operator = row.operator("gamerigtool.toggle_constraint", text="Unmute", icon="HIDE_OFF")
     # operator.mute = False
     # operator.use_selected = addon_preferences.use_selected
 
@@ -168,13 +168,13 @@ def draw_panel(self, context, layout):
         row = subpanel.row(align=True)
 
         operator = row.operator(
-            "gamerigtool.toogle_constraint", text="Mute", icon="HIDE_ON"
+            "gamerigtool.toggle_constraint", text="Mute", icon="HIDE_ON"
         )
         operator.mute = True
         operator.use_selected = addon_preferences.use_selected
 
         operator = row.operator(
-            "gamerigtool.toogle_constraint", text="Unmute", icon="HIDE_OFF"
+            "gamerigtool.toggle_constraint", text="Unmute", icon="HIDE_OFF"
         )
         operator.mute = False
         operator.use_selected = addon_preferences.use_selected

--- a/GRT_Action_Bakery.py
+++ b/GRT_Action_Bakery.py
@@ -83,7 +83,7 @@ class GRT_OT_Toggle_Rig(bpy.types.Operator):
             bpy.ops.object.mode_set(mode="OBJECT", toggle=False)
 
             if Global_Settings.toggle_mute:
-                bpy.ops.gamerigtool.toogle_game_rig_constraint(
+                bpy.ops.gamerigtool.toggle_game_rig_constraint(
                     mute=False, use_selected=False
                 )
 
@@ -107,7 +107,7 @@ class GRT_OT_Toggle_Rig(bpy.types.Operator):
 
             bpy.ops.object.mode_set(mode="OBJECT", toggle=False)
             if Global_Settings.toggle_mute:
-                bpy.ops.gamerigtool.toogle_game_rig_constraint(
+                bpy.ops.gamerigtool.toggle_game_rig_constraint(
                     mute=True, use_selected=False
                 )
 
@@ -380,7 +380,7 @@ class GRT_PT_Action_Bakery(bpy.types.Panel):
     # @classmethod
     # def poll(cls, context):
 
-    # Top Bar Toogle Constraint Update
+    # Top Bar toggle Constraint Update
 
     # addon_preferences = context.preferences.addons[addon_name].preferences
     #
@@ -399,13 +399,13 @@ class GRT_PT_Action_Bakery(bpy.types.Panel):
         row = layout.row(align=True)
 
         # operator = row.operator(
-        #     "gamerigtool.toogle_game_rig_constraint", text="Mute", icon="HIDE_ON"
+        #     "gamerigtool.toggle_game_rig_constraint", text="Mute", icon="HIDE_ON"
         # )
         # operator.mute = True
         # operator.use_selected = addon_preferences.use_selected
         #
         # operator = row.operator(
-        #     "gamerigtool.toogle_game_rig_constraint", text="Unmute", icon="HIDE_OFF"
+        #     "gamerigtool.toggle_game_rig_constraint", text="Unmute", icon="HIDE_OFF"
         # )
         # operator.mute = False
         # operator.use_selected = addon_preferences.use_selected
@@ -430,7 +430,7 @@ class GRT_PT_Action_Bakery(bpy.types.Panel):
         if len(constraint_state) > 0:
             if all(constraint_state):
                 operator = row.operator(
-                    "gamerigtool.toogle_game_rig_constraint",
+                    "gamerigtool.toggle_game_rig_constraint",
                     text="Connected",
                     icon="LINKED",
                     depress=True,
@@ -443,7 +443,7 @@ class GRT_PT_Action_Bakery(bpy.types.Panel):
                 # )
             else:
                 operator = row.operator(
-                    "gamerigtool.toogle_game_rig_constraint",
+                    "gamerigtool.toggle_game_rig_constraint",
                     text="Disconnected",
                     icon="UNLINKED",
                     depress=False,

--- a/GRT_Extra_Operators/GRT_Constraint_Toogle.py
+++ b/GRT_Extra_Operators/GRT_Constraint_Toogle.py
@@ -3,11 +3,11 @@ import bpy
 # Editing bone
 
 
-class GRT_Constraint_Toogle(bpy.types.Operator):
-    """Constraint Toogle"""
+class GRT_Constraint_Toggle(bpy.types.Operator):
+    """Constraint Toggle"""
 
-    bl_idname = "gamerigtool.toogle_constraint"
-    bl_label = "Toogle Constraints"
+    bl_idname = "gamerigtool.toggle_constraint"
+    bl_label = "Toggle Constraints"
     bl_options = {"REGISTER", "UNDO"}
 
     mute: bpy.props.BoolProperty()
@@ -39,11 +39,11 @@ class GRT_Constraint_Toogle(bpy.types.Operator):
         return {"FINISHED"}
 
 
-class GRT_Constraint_Game_Rig_Toogle(bpy.types.Operator):
-    """Constraint Game Rig Toogle"""
+class GRT_Constraint_Game_Rig_Toggle(bpy.types.Operator):
+    """Constraint Game Rig Toggle"""
 
-    bl_idname = "gamerigtool.toogle_game_rig_constraint"
-    bl_label = "Toogle Game Rig Constraints"
+    bl_idname = "gamerigtool.toggle_game_rig_constraint"
+    bl_label = "Toggle Game Rig Constraints"
     bl_options = {"REGISTER", "UNDO"}
 
     mute: bpy.props.BoolProperty()
@@ -79,7 +79,7 @@ class GRT_Constraint_Game_Rig_Toogle(bpy.types.Operator):
         return {"FINISHED"}
 
 
-classes = [GRT_Constraint_Toogle, GRT_Constraint_Game_Rig_Toogle]
+classes = [GRT_Constraint_Toggle, GRT_Constraint_Game_Rig_Toggle]
 
 
 def register():

--- a/GRT_Extra_Operators/__init__.py
+++ b/GRT_Extra_Operators/__init__.py
@@ -1,6 +1,6 @@
 import bpy
 from . import GRT_Constraint_To_Armature
-from . import GRT_Constraint_Toogle
+from . import GRT_Constraint_Toggle
 from . import GRT_Remove_Animation_Data
 from . import GRT_Remove_BBone
 from . import GRT_Remove_Bone_Shape
@@ -31,7 +31,7 @@ modules = [
     GRT_Clear_All_Bones_Constraints,
     GRT_Batch_Rename_Actions,
     GRT_Constraint_To_Armature,
-    GRT_Constraint_Toogle,
+    GRT_Constraint_Toggle,
     GRT_Remove_Animation_Data,
     GRT_Remove_BBone,
     GRT_Remove_Bone_Shape,

--- a/Preferences.py
+++ b/Preferences.py
@@ -46,13 +46,13 @@ class CGD_user_preferences(bpy.types.AddonPreferences):
     show_armature_display: bpy.props.BoolProperty(default=False)
 
     show_action_bakery: bpy.props.BoolProperty(default=False)
-    toogle_constraints: bpy.props.BoolProperty(default=False)
+    toggle_constraints: bpy.props.BoolProperty(default=False)
 
     game_rig_tool_panel_name: bpy.props.StringProperty(
-        default="Game Rig Tool", update=update_panel
+        default="Game Rig Tools", update=update_panel
     )
     action_bakery_panel_name: bpy.props.StringProperty(
-        default="Game Rig Tool", update=update_panel
+        default="Game Rig Tools", update=update_panel
     )
 
     use_selected: bpy.props.BoolProperty(default=False)
@@ -63,12 +63,12 @@ class CGD_user_preferences(bpy.types.AddonPreferences):
 
     def draw(self, context):
         layout = self.layout
-        layout.prop(self, "action_bakery_panel_name", text="Game Rig Tool Tab")
+        layout.prop(self, "action_bakery_panel_name", text="Game Rig Tools Tab")
         layout.prop(self, "game_rig_tool_panel_name", text="Utility Tab")
 
-        layout.prop(self, "toogle_constraints", text="Top Bar Toogle Constraint")
+        layout.prop(self, "toggle_constraints", text="Top Bar Toggle Constraint")
 
-        layout.label(text="Operators Options")
+        layout.label(text="Operator Options")
         layout.prop(
             self,
             "OPERATOR_APPLYMENU_Apply_Armature_Scale",


### PR DESCRIPTION
👋 Yo! First off... thank you so much for such an amazing Blender add-on 🙏 

I just wanted to pass along a small contribution after noticing a few spelling/grammar issues in some of the wordings upon installing the add-on and configuring its preferences:

- Corrected "Toogle" to "Toggle"
- Changed default panel name from "Game Rig Tool" to "Game Rig Tools"
- Changed "Operators Options" to "Operator Options"